### PR TITLE
Fix LDAP auth source editing when using AuthSourceLdapPasswd.

### DIFF
--- a/app/models/auth_source_ldap_passwd.rb
+++ b/app/models/auth_source_ldap_passwd.rb
@@ -8,7 +8,11 @@ class AuthSourceLdapPasswd < AuthSourceLdap
 
     attrs = get_user_dn(user.login, password)
     if attrs && attrs[:dn]
-      ldap_con = initialize_ldap_con(self.account, self.account_password)
+      if self.account && self.account.include?("$login")
+        ldap_con = initialize_ldap_con(self.account.sub("$login", Net::LDAP::DN.escape(user.login)), password)
+      else
+        ldap_con = initialize_ldap_con(self.account, self.account_password)
+      end
 
       ops = [[:replace, :unicodePwd, AuthSourceLdapPasswd.str2unicodePwd(new_password)]]
       ldap_con.modify :dn => attrs[:dn], :operations => ops

--- a/init.rb
+++ b/init.rb
@@ -1,13 +1,14 @@
 require 'redmine'
 
 require_dependency 'redmine_ldap_passwd_my_controller_patch'
+require_dependency 'redmine_ldap_passwd_auth_sources_helper_patch'
 require_dependency 'redmine_ldap_passwd_account_controller_patch'
 
 Redmine::Plugin.register :redmine_ldap_passwd do
   name 'Redmine LDAP Change Password'
   author 'Yura Zaplavnov'
   description 'The plugin extends AuthSourceLdap to introduce the ability to recover or change user password.'
-  version '3.0'
+  version '3.0.1'
   url 'https://github.com/xeagle2/redmine_ldap_passwd'
   author_url 'https://github.com/xeagle2'
 end
@@ -17,11 +18,13 @@ require 'dispatcher' unless Rails::VERSION::MAJOR >= 3
 if Rails::VERSION::MAJOR >= 3
   ActionDispatch::Callbacks.to_prepare do
     MyController.send(:include, RedmineLdapPasswd::MyControllerPatch)
+    AuthSourcesHelper.send(:include, RedmineLdapPasswd::AuthSourcesHelperPatch)
     AccountController.send(:include, RedmineLdapPasswd::AccountControllerPatch)
   end
 else
   Dispatcher.to_prepare do
     MyController.send(:include, RedmineLdapPasswd::MyControllerPatch)
+    AuthSourcesHelper.send(:include, RedmineLdapPasswd::AuthSourcesHelperPatch)
     AccountController.send(:include, RedmineLdapPasswd::AccountControllerPatch)
   end
 end

--- a/lib/redmine_ldap_passwd_auth_sources_helper_patch.rb
+++ b/lib/redmine_ldap_passwd_auth_sources_helper_patch.rb
@@ -1,0 +1,20 @@
+module RedmineLdapPasswd
+  module AuthSourcesHelperPatch
+    def self.included(base) # :nodoc:
+      base.send(:include, InstanceMethods)
+
+      base.class_eval do
+        unloadable # Send unloadable so it will not be unloaded in development
+
+        alias_method_chain :auth_source_partial_name, :ignored_passwd
+      end
+    end
+
+    module InstanceMethods
+      # Make sure AuthSourceLdapPasswd is loaded with the same form as AuthSourceLdap
+      def auth_source_partial_name_with_ignored_passwd(auth_source)
+        "form_#{auth_source.class.name.underscore}".chomp('_passwd')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Xeagle2, 

If you change the type-column in auth_sources table to AuthSourceLdapPasswd, you are no longer able to edit the corresponding LDAP authentication source through its form, since the view does not exist. I wrote a helper to override the default auth_source_partial_name helper so the extra `_passwd` suffix is ignored.

Included a fix when you use an account with $login parameter for your LDAP connection, consistent with the redmine ldap_con procedure.

Increased version to 3.0.1 in this PR.

Sincerely,
Gregory